### PR TITLE
Add image-based gradient backgrounds to article cards

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import { getArticle } from "@/lib/articlesDb";
 import sanitizeHtml from "sanitize-html";
+import Link from "next/link";
 
 // Types
 type Params = { slug: string };
@@ -86,8 +87,8 @@ export default async function ArticlePage({ params }: { params: Promise<Params> 
   const plain = htmlToPlainText(article.contentHtml || "");
   const readMin = calcReadingMinutes(plain);
 
-  const updatedAt = (article as any)?.updatedAt ? new Date((article as any).updatedAt) : null;
-  const author = (article as any)?.author || null;
+  const updatedAt = article.updatedAt ? new Date(article.updatedAt) : null;
+  const author = (article as { author?: string }).author || null;
 
   const safeHtml = sanitizeHtml(article.contentHtml, sanitizeOptions);
 
@@ -104,12 +105,12 @@ export default async function ArticlePage({ params }: { params: Promise<Params> 
                 { label: article.title },
               ]}
             />
-            <a
+            <Link
               href={`/admin/articles/${article.slug}/edit`}
               className="inline-flex items-center rounded-full border border-black/10 dark:border-white/15 px-3 py-1 text-xs font-medium hover:border-brand/60"
             >
               Edit
-            </a>
+            </Link>
           </div>
         </div>
       </div>
@@ -150,14 +151,14 @@ export default async function ArticlePage({ params }: { params: Promise<Params> 
         {article.tags && article.tags.length > 0 ? (
           <div className="mt-4 flex flex-wrap gap-2 text-xs">
             {article.tags.map((t: string) => (
-              <a
+              <Link
                 key={t}
                 href={`/articles?q=${encodeURIComponent(t)}`}
                 className="group inline-flex items-center gap-1 rounded-full border border-black/10 px-3 py-1 text-foreground/70 hover:border-brand/60 hover:text-foreground dark:border-white/15"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-brand/60 transition group-hover:bg-brand" />
                 #{t}
-              </a>
+              </Link>
             ))}
           </div>
         ) : null}
@@ -188,9 +189,21 @@ export default async function ArticlePage({ params }: { params: Promise<Params> 
             <div className="rounded-2xl border border-black/10 p-4 dark:border-white/10">
               <div className="text-xs font-semibold uppercase tracking-wider text-foreground/60">Related</div>
               <ul className="mt-3 space-y-2 text-sm text-foreground/70">
-                <li><a href="/articles?q=training" className="hover:text-foreground">Training basics</a></li>
-                <li><a href="/articles?q=policy" className="hover:text-foreground">Company policies</a></li>
-                <li><a href="/articles?q=safety" className="hover:text-foreground">Safety guides</a></li>
+                <li>
+                  <Link href="/articles?q=training" className="hover:text-foreground">
+                    Training basics
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/articles?q=policy" className="hover:text-foreground">
+                    Company policies
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/articles?q=safety" className="hover:text-foreground">
+                    Safety guides
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,10 +48,10 @@ export default function Home() {
                       <div className="mt-1 font-medium line-clamp-3">{q.title}</div>
                       <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{q.description}</p>
                       <div className="mt-auto pt-3">
-                        <a href={`/articles/${q.slug}`} className="text-sm text-brand hover:underline">Open</a>
+                        <Link href={`/articles/${q.slug}`} className="text-sm text-brand hover:underline">Open</Link>
                       </div>
-                    </li>
-                  ))}
+                      </li>
+                    ))}
                   {/* placeholders to keep 3-in-row layout */}
                   {Array.from({ length: Math.max(0, 3 - quickArticles.length) }).map((_, i) => (
                     <li

--- a/src/components/ArticleCardPreview.tsx
+++ b/src/components/ArticleCardPreview.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useImageGradient } from "@/lib/useImageGradient";
+
 type Props = {
   title: string;
   description: string;
@@ -17,8 +21,12 @@ export default function ArticleCardPreview({
   imageY = 50,
   className = "",
 }: Props) {
+  const gradient = useImageGradient(imageUrl);
   return (
-    <div className={`relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5] ${className}`}>
+    <div
+      className={`relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5] ${className}`}
+      style={gradient ? { background: gradient } : undefined}
+    >
       {imageUrl && (
         <img
           src={imageUrl}

--- a/src/components/ArticlesExplorer.tsx
+++ b/src/components/ArticlesExplorer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useImageGradient } from "@/lib/useImageGradient";
 
 type Item = {
   slug: string;
@@ -100,38 +101,48 @@ export default function ArticlesExplorer({
       ) : (
         <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((a) => (
-            <li key={a.slug} className="relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5]">
-              {a.imageUrl && (
-                <img
-                  src={a.imageUrl}
-                  alt=""
-                  aria-hidden="true"
-                  className="pointer-events-none select-none absolute max-w-none"
-                  style={{ left: `${a.imageX ?? 50}%`, top: `${a.imageY ?? 50}%`, transform: 'translate(-50%, -50%)', width: '130%' }}
-                />
-              )}
-              <div className="relative z-10 flex h-full flex-col">
-                <div className="text-xs uppercase tracking-wide text-foreground/60">
-                  {a.department}
-                </div>
-                <h3 className="mt-1 font-medium">
-                  <Link href={`/articles/${a.slug}`} className="hover:text-brand">
-                    {a.title}
-                  </Link>
-                </h3>
-                <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{a.description}</p>
-                {a.tags && a.tags.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-2 text-xs text-foreground/60">
-                    {a.tags.map((t) => (
-                      <span key={t} className="rounded-full border border-black/10 dark:border-white/15 px-2 py-1">#{t}</span>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </li>
+            <ArticleItem key={a.slug} item={a} />
           ))}
         </ul>
       )}
     </div>
+  );
+}
+
+type ArticleItemProps = { item: Item };
+
+function ArticleItem({ item }: ArticleItemProps) {
+  const gradient = useImageGradient(item.imageUrl);
+  return (
+    <li
+      className="relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5]"
+      style={gradient ? { background: gradient } : undefined}
+    >
+      {item.imageUrl && (
+        <img
+          src={item.imageUrl}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none select-none absolute max-w-none"
+          style={{ left: `${item.imageX ?? 50}%`, top: `${item.imageY ?? 50}%`, transform: 'translate(-50%, -50%)', width: '130%' }}
+        />
+      )}
+      <div className="relative z-10 flex h-full flex-col">
+        <div className="text-xs uppercase tracking-wide text-foreground/60">{item.department}</div>
+        <h3 className="mt-1 font-medium">
+          <Link href={`/articles/${item.slug}`} className="hover:text-brand">
+            {item.title}
+          </Link>
+        </h3>
+        <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{item.description}</p>
+        {item.tags && item.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-foreground/60">
+            {item.tags.map((t) => (
+              <span key={t} className="rounded-full border border-black/10 dark:border-white/15 px-2 py-1">#{t}</span>
+            ))}
+          </div>
+        )}
+      </div>
+    </li>
   );
 }

--- a/src/lib/useImageGradient.ts
+++ b/src/lib/useImageGradient.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+// Computes a simple two-color gradient based on the left and right halves of an image
+export function useImageGradient(src?: string) {
+  const [gradient, setGradient] = useState<string>();
+
+  useEffect(() => {
+    if (!src) return;
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.src = src;
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        const size = 20; // small sample for performance
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.drawImage(img, 0, 0, size, size);
+        const { data } = ctx.getImageData(0, 0, size, size);
+        const left = [0, 0, 0];
+        const right = [0, 0, 0];
+        let cl = 0;
+        let cr = 0;
+        for (let y = 0; y < size; y++) {
+          for (let x = 0; x < size; x++) {
+            const i = (y * size + x) * 4;
+            const r = data[i];
+            const g = data[i + 1];
+            const b = data[i + 2];
+            if (x < size / 2) {
+              left[0] += r;
+              left[1] += g;
+              left[2] += b;
+              cl++;
+            } else {
+              right[0] += r;
+              right[1] += g;
+              right[2] += b;
+              cr++;
+            }
+          }
+        }
+        const c1 = `rgb(${Math.round(left[0] / cl)}, ${Math.round(left[1] / cl)}, ${Math.round(left[2] / cl)})`;
+        const c2 = `rgb(${Math.round(right[0] / cr)}, ${Math.round(right[1] / cr)}, ${Math.round(right[2] / cr)})`;
+        setGradient(`linear-gradient(135deg, ${c1}, ${c2})`);
+      } catch {
+        // ignore errors
+      }
+    };
+  }, [src]);
+
+  return gradient;
+}
+


### PR DESCRIPTION
## Summary
- derive a two-tone gradient from article images with `useImageGradient`
- apply image-based gradient backgrounds to `ArticleCardPreview` and article explorer cards
- replace inline links with `Link` and remove `any` typings on article page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c017632e2083248eac259f5b16f8a3