### PR TITLE
feat: unify article cards

### DIFF
--- a/src/app/admin/articles/[slug]/edit/page.tsx
+++ b/src/app/admin/articles/[slug]/edit/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import RichEditor from "@/components/RichEditor";
-import ArticleCardPreview from "@/components/ArticleCardPreview";
+import ArticleCard from "@/components/ArticleCard";
 import Modal from "@/components/Modal";
 import Icon from "@/components/Icon";
 // departments loaded from API
@@ -220,7 +220,7 @@ export default function EditArticlePage() {
                   <input type="number" min={0} max={100} value={cardY} onChange={(e) => setCardY(Number(e.target.value))} className="w-16 rounded-full border border-black/10 dark:border-white/15 bg-background px-2 py-1" />
                 </div>
               </div>
-              <ArticleCardPreview className="w-full" title={title} description={description} department={department} imageUrl={cardImageUrl} imageX={cardX} imageY={cardY} />
+              <ArticleCard className="w-full" title={title} description={description} department={department} imageUrl={cardImageUrl} imageX={cardX} imageY={cardY} />
             </div>
 
             {/* Quick links actions */}
@@ -231,6 +231,10 @@ export default function EditArticlePage() {
                 <button type="button" onClick={addToQuick} className="inline-flex items-center gap-2 rounded-full border border-black/10 dark:border-white/15 px-4 py-2 text-sm font-medium hover:border-brand/60"><Icon name="star" /> Add to quick</button>
               )}
             </div>
+
+            {error && (
+              <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">{error}</div>
+            )}
 
             {/* Actions */}
             <div className="flex gap-3">

--- a/src/app/admin/articles/new/page.tsx
+++ b/src/app/admin/articles/new/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import RichEditor from "@/components/RichEditor";
-import ArticleCardPreview from "@/components/ArticleCardPreview";
+import ArticleCard from "@/components/ArticleCard";
 
 export default function NewArticlePage() {
   const [title, setTitle] = useState("");
@@ -129,7 +129,7 @@ export default function NewArticlePage() {
                   <input type="number" min={0} max={100} value={cardY} onChange={(e) => setCardY(Number(e.target.value))} className="w-16 rounded-full border border-black/10 dark:border-white/15 bg-background px-2 py-1" />
                 </div>
               </div>
-              <ArticleCardPreview className="w-full" title={title} description={description} department={department} imageUrl={cardImageUrl} imageX={cardX} imageY={cardY} />
+              <ArticleCard className="w-full" title={title} description={description} department={department} imageUrl={cardImageUrl} imageX={cardX} imageY={cardY} />
             </div>
 
             {tags.length > 0 && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { listQuickArticles } from "@/lib/quickArticlesDb";
 import { listArticles } from "@/lib/articlesDb";
+import ArticleCard from "@/components/ArticleCard";
 
 export const dynamic = "force-dynamic";
 
@@ -101,25 +102,17 @@ export default function Home() {
         ) : (
           <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {articles.map((a) => (
-              <li key={a.slug} className="relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5]">
-                {a.imageUrl && (
-                  <img
-                    src={a.imageUrl}
-                    alt=""
-                    aria-hidden="true"
-                    className="pointer-events-none select-none absolute max-w-none"
-                    style={{ left: `${a.imageX ?? 50}%`, top: `${a.imageY ?? 50}%`, transform: 'translate(-50%, -50%)', width: '130%' }}
-                  />
-                )}
-                <div className="relative z-10 flex h-full flex-col">
-                  <div className="text-xs uppercase tracking-wide text-foreground/60">{a.department}</div>
-                  <h3 className="mt-1 font-medium">
-                    <Link href={`/articles/${a.slug}`} className="hover:text-brand">
-                      {a.title}
-                    </Link>
-                  </h3>
-                  <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{a.description}</p>
-                </div>
+              <li key={a.slug}>
+                <ArticleCard
+                  title={a.title}
+                  description={a.description}
+                  department={a.department}
+                  tags={a.tags}
+                  imageUrl={a.imageUrl}
+                  imageX={a.imageX}
+                  imageY={a.imageY}
+                  href={`/articles/${a.slug}`}
+                />
               </li>
             ))}
           </ul>

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useImageGradient } from "@/lib/useImageGradient";
 
 type Props = {
@@ -9,16 +10,20 @@ type Props = {
   imageUrl?: string;
   imageX?: number;
   imageY?: number;
+  tags?: string[];
+  href?: string;
   className?: string;
 };
 
-export default function ArticleCardPreview({
+export default function ArticleCard({
   title,
   description,
   department,
   imageUrl,
   imageX = 50,
   imageY = 50,
+  tags,
+  href,
   className = "",
 }: Props) {
   const gradient = useImageGradient(imageUrl);
@@ -37,9 +42,26 @@ export default function ArticleCardPreview({
         />
       )}
       <div className="relative z-10 flex h-full flex-col">
-        <div className="text-xs uppercase tracking-wide text-foreground/60">{department || 'Article'}</div>
-        <h3 className="mt-1 font-medium">{title || 'Title'}</h3>
-        <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{description || 'Description'}</p>
+        <div className="text-xs uppercase tracking-wide text-foreground/60">{department || "Article"}</div>
+        <h3 className="mt-1 font-medium">
+          {href ? (
+            <Link href={href} className="hover:text-brand">
+              {title || "Title"}
+            </Link>
+          ) : (
+            title || "Title"
+          )}
+        </h3>
+        <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{description || "Description"}</p>
+        {tags && tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-foreground/60">
+            {tags.map((t) => (
+              <span key={t} className="rounded-full border border-black/10 dark:border-white/15 px-2 py-1">
+                #{t}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/ArticlesExplorer.tsx
+++ b/src/components/ArticlesExplorer.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useImageGradient } from "@/lib/useImageGradient";
+import ArticleCard from "@/components/ArticleCard";
 
 type Item = {
   slug: string;
@@ -101,48 +100,21 @@ export default function ArticlesExplorer({
       ) : (
         <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((a) => (
-            <ArticleItem key={a.slug} item={a} />
+            <li key={a.slug}>
+              <ArticleCard
+                title={a.title}
+                description={a.description}
+                department={a.department}
+                tags={a.tags}
+                imageUrl={a.imageUrl}
+                imageX={a.imageX}
+                imageY={a.imageY}
+                href={`/articles/${a.slug}`}
+              />
+            </li>
           ))}
         </ul>
       )}
     </div>
-  );
-}
-
-type ArticleItemProps = { item: Item };
-
-function ArticleItem({ item }: ArticleItemProps) {
-  const gradient = useImageGradient(item.imageUrl);
-  return (
-    <li
-      className="relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5]"
-      style={gradient ? { background: gradient } : undefined}
-    >
-      {item.imageUrl && (
-        <img
-          src={item.imageUrl}
-          alt=""
-          aria-hidden="true"
-          className="pointer-events-none select-none absolute max-w-none"
-          style={{ left: `${item.imageX ?? 50}%`, top: `${item.imageY ?? 50}%`, transform: 'translate(-50%, -50%)', width: '130%' }}
-        />
-      )}
-      <div className="relative z-10 flex h-full flex-col">
-        <div className="text-xs uppercase tracking-wide text-foreground/60">{item.department}</div>
-        <h3 className="mt-1 font-medium">
-          <Link href={`/articles/${item.slug}`} className="hover:text-brand">
-            {item.title}
-          </Link>
-        </h3>
-        <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{item.description}</p>
-        {item.tags && item.tags.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-2 text-xs text-foreground/60">
-            {item.tags.map((t) => (
-              <span key={t} className="rounded-full border border-black/10 dark:border-white/15 px-2 py-1">#{t}</span>
-            ))}
-          </div>
-        )}
-      </div>
-    </li>
   );
 }


### PR DESCRIPTION
## Summary
- replace ArticleCardPreview with shared ArticleCard component supporting tags, links, and gradient backgrounds
- render ArticleCard in home page article list and ArticlesExplorer
- use shared card preview in admin article pages and display save errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c01ce840048324839ff3a9c1e90329