### PR TITLE
feat: add hover blur and text scaling to ArticleCard

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -29,7 +29,7 @@ export default function ArticleCard({
   const gradient = useImageGradient(imageUrl);
   return (
     <div
-      className={`relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5] ${className}`}
+      className={`group relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5] ${className}`}
       style={gradient ? { background: gradient } : undefined}
     >
       {imageUrl && (
@@ -37,11 +37,14 @@ export default function ArticleCard({
           src={imageUrl}
           alt=""
           aria-hidden="true"
-          className="pointer-events-none select-none absolute max-w-none"
-          style={{ left: `${imageX}%`, top: `${imageY}%`, transform: 'translate(-50%, -50%)', width: '130%' }}
+          className="pointer-events-none select-none absolute max-w-none transition duration-300 ease-out group-hover:blur-xl"
+          style={{ left: `${imageX}%`, top: `${imageY}%`, transform: 'translate(-50%, -50%)', width: '130%', willChange: 'filter' }}
         />
       )}
-      <div className="relative z-10 flex h-full flex-col">
+      <div
+        className="relative z-10 flex h-full flex-col transition-transform duration-300 ease-out group-hover:scale-[1.03]"
+        style={{ willChange: 'transform' }}
+      >
         <div className="text-xs uppercase tracking-wide text-foreground/60">{department || "Article"}</div>
         <h3 className="mt-1 font-medium">
           {href ? (


### PR DESCRIPTION
## Summary
- apply strong blur to card image on hover
- scale text content slightly on hover for emphasis

## Testing
- `npm test`
- `npm run lint` *(fails: warning no-img-element)*

------
https://chatgpt.com/codex/tasks/task_e_68c01f06bdb88324b7a41888623e12db