### PR TITLE
Enhance quick link cards with gradient hover image

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { listQuickArticles } from "@/lib/quickArticlesDb";
 import { listArticles } from "@/lib/articlesDb";
 import ArticleCard from "@/components/ArticleCard";
+import QuickArticleCard from "@/components/QuickArticleCard";
 
 export const dynamic = "force-dynamic";
 
@@ -41,18 +42,18 @@ export default function Home() {
               {quickArticles.length > 0 && (
                 <>
                   {quickArticles.map((q) => (
-                    <li
-                      key={q.slug}
-                      className="rounded-2xl border border-black/10 dark:border-white/15 p-4 hover:border-brand/50 h-64 flex flex-col overflow-hidden"
-                    >
-                      <div className="text-xs uppercase tracking-wide text-foreground/60">{q.department || "Article"}</div>
-                      <div className="mt-1 font-medium line-clamp-3">{q.title}</div>
-                      <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{q.description}</p>
-                      <div className="mt-auto pt-3">
-                        <Link href={`/articles/${q.slug}`} className="text-sm text-brand hover:underline">Open</Link>
-                      </div>
-                      </li>
-                    ))}
+                    <li key={q.slug} className="h-64">
+                      <QuickArticleCard
+                        title={q.title}
+                        description={q.description}
+                        department={q.department || undefined}
+                        imageUrl={q.imageUrl}
+                        imageX={q.imageX}
+                        imageY={q.imageY}
+                        href={`/articles/${q.slug}`}
+                      />
+                    </li>
+                  ))}
                   {/* placeholders to keep 3-in-row layout */}
                   {Array.from({ length: Math.max(0, 3 - quickArticles.length) }).map((_, i) => (
                     <li

--- a/src/components/QuickArticleCard.tsx
+++ b/src/components/QuickArticleCard.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import Link from "next/link";
+import { useImageGradient } from "@/lib/useImageGradient";
+
+interface Props {
+  title: string;
+  description: string;
+  department?: string;
+  href: string;
+  imageUrl?: string;
+  imageX?: number;
+  imageY?: number;
+  className?: string;
+}
+
+export default function QuickArticleCard({
+  title,
+  description,
+  department,
+  href,
+  imageUrl,
+  imageX = 50,
+  imageY = 50,
+  className = "",
+}: Props) {
+  const gradient = useImageGradient(imageUrl);
+  return (
+    <div
+      className={`group relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 flex flex-col transition hover:border-brand/50 h-full ${className}`}
+      style={gradient ? { background: gradient } : undefined}
+    >
+      {imageUrl && (
+        <img
+          src={imageUrl}
+          alt=""
+          aria-hidden="true"
+          className="pointer-events-none select-none absolute max-w-none transition duration-300 ease-out group-hover:blur-xl"
+          style={{ left: `${imageX}%`, top: `${imageY}%`, transform: 'translate(-50%, -50%)', width: '130%', willChange: 'filter' }}
+        />
+      )}
+      <div
+        className="relative z-10 flex flex-col h-full transition-transform duration-300 ease-out group-hover:scale-[1.03]"
+        style={{ willChange: 'transform' }}
+      >
+        <div className="text-xs uppercase tracking-wide text-foreground/60">{department || "Article"}</div>
+        <div className="mt-1 font-medium line-clamp-3">{title}</div>
+        <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{description}</p>
+        <div className="mt-auto pt-3">
+          <Link href={href} className="text-sm text-brand hover:underline">
+            Open
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/lib/quickArticlesDb.ts
+++ b/src/lib/quickArticlesDb.ts
@@ -4,7 +4,10 @@ export type QuickArticle = {
   slug: string;
   title: string;
   description: string;
-  department?: string | null;
+  department?: string;
+  imageUrl?: string;
+  imageX?: number;
+  imageY?: number;
   position: number;
 };
 
@@ -18,13 +21,31 @@ export function listQuickArticles(): QuickArticle[] {
   const db = getDb();
   const rows = db
     .prepare(
-      `SELECT a.slug, a.title, a.description, a.department, qa.position
+      `SELECT a.slug, a.title, a.description, a.department, a.image_url as imageUrl, a.image_x as imageX, a.image_y as imageY, qa.position
        FROM quick_articles qa
        JOIN articles a ON a.id = qa.article_id
        ORDER BY qa.position ASC`
     )
-    .all() as QuickArticle[];
-  return rows;
+    .all() as Array<{
+      slug: string;
+      title: string;
+      description: string;
+      department?: string | null;
+      imageUrl?: string | null;
+      imageX?: number | null;
+      imageY?: number | null;
+      position: number;
+    }>;
+  return rows.map((r) => ({
+    slug: r.slug,
+    title: r.title,
+    description: r.description,
+    department: r.department || undefined,
+    imageUrl: r.imageUrl || undefined,
+    imageX: r.imageX ?? undefined,
+    imageY: r.imageY ?? undefined,
+    position: r.position,
+  }));
 }
 
 export function isQuickArticle(slug: string): boolean {


### PR DESCRIPTION
## Summary
- add QuickArticleCard component with gradient background and blur-on-hover image
- extend quick article data to include image metadata
- render quick article cards with new component on home page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c020db0f388324a9605784ce5edb1e