### PR TITLE
Make article cards clickable and remove open buttons

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -27,9 +27,11 @@ export default function ArticleCard({
   className = "",
 }: Props) {
   const gradient = useImageGradient(imageUrl);
+  const Wrapper = href ? Link : "div";
   return (
-    <div
-      className={`group relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5] ${className}`}
+    <Wrapper
+      {...(href ? { href } : {})}
+      className={`group relative block overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 aspect-[6/5] ${className}`}
       style={gradient ? { background: gradient } : undefined}
     >
       {imageUrl && (
@@ -46,14 +48,8 @@ export default function ArticleCard({
         style={{ willChange: 'transform' }}
       >
         <div className="text-xs uppercase tracking-wide text-foreground/60">{department || "Article"}</div>
-        <h3 className="mt-1 font-medium">
-          {href ? (
-            <Link href={href} className="hover:text-brand">
-              {title || "Title"}
-            </Link>
-          ) : (
-            title || "Title"
-          )}
+        <h3 className="mt-1 font-medium group-hover:text-brand">
+          {title || "Title"}
         </h3>
         <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{description || "Description"}</p>
         {tags && tags.length > 0 && (
@@ -66,7 +62,7 @@ export default function ArticleCard({
           </div>
         )}
       </div>
-    </div>
+    </Wrapper>
   );
 }
 

--- a/src/components/QuickArticleCard.tsx
+++ b/src/components/QuickArticleCard.tsx
@@ -26,7 +26,8 @@ export default function QuickArticleCard({
 }: Props) {
   const gradient = useImageGradient(imageUrl);
   return (
-    <div
+    <Link
+      href={href}
       className={`group relative overflow-hidden rounded-2xl border border-black/10 dark:border-white/15 p-4 flex flex-col transition hover:border-brand/50 h-full ${className}`}
       style={gradient ? { background: gradient } : undefined}
     >
@@ -44,15 +45,10 @@ export default function QuickArticleCard({
         style={{ willChange: 'transform' }}
       >
         <div className="text-xs uppercase tracking-wide text-foreground/60">{department || "Article"}</div>
-        <div className="mt-1 font-medium line-clamp-3">{title}</div>
+        <div className="mt-1 font-medium line-clamp-3 group-hover:text-brand">{title}</div>
         <p className="mt-1 text-sm text-foreground/70 line-clamp-4">{description}</p>
-        <div className="mt-auto pt-3">
-          <Link href={href} className="text-sm text-brand hover:underline">
-            Open
-          </Link>
-        </div>
       </div>
-    </div>
+    </Link>
   );
 }
 


### PR DESCRIPTION
## Summary
- Allow full article cards to be clickable without separate title links
- Simplify quick link cards so the whole card navigates and remove redundant "Open" button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02395bbbc83249a183bb63480c695