### PR TITLE
Fix Tailwind plugin configuration

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,9 @@
+import tailwindcss from "@tailwindcss/postcss";
+
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: {
+    tailwindcss,
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- ensure Tailwind CSS plugin is properly loaded via PostCSS config

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_68c027698b20832494bd92e061fcd43c